### PR TITLE
Fix Windows Desktop Runtime URL

### DIFF
--- a/misc_scripts/GoASetupScript.sh
+++ b/misc_scripts/GoASetupScript.sh
@@ -5,7 +5,7 @@ mkdir ~/Documents/SeedGenerator
 cd ~/SeedSetup
 wget https://github.com/OpenKH/OpenKh/releases/download/latest/openkh.zip
 wget https://github.com/tommadness/KH2Randomizer/releases/latest/download/KH2.Randomizer.exe
-wget https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/8.0.22/windowsdesktop-runtime-8.0.20-win-x64.exe
+wget https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/8.0.22/windowsdesktop-runtime-8.0.22-win-x64.exe
 unzip openkh.zip -d ~/Documents
 mv ~/Documents/openkh ~/Documents/OpenKH
 mv ~/SeedSetup/KH2.Randomizer.exe ~/Documents/SeedGenerator


### PR DESCRIPTION
The Windows Desktop Runtime URL has a typo that prevent the shell script from executing fully. This pull request should fix the URL and allow the script to work again.